### PR TITLE
Add FnvHashMap and FnvHashSet type aliases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fnv"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 description = "Fowler–Noll–Vo hash function"
 license = "Apache-2.0 / MIT"

--- a/README.md
+++ b/README.md
@@ -39,34 +39,39 @@ fnv = "1.0.3"
 
 ## Using FNV in a HashMap
 
-To configure a `HashMap` in the standard library to use the FNV hasher, you
-must create a default instance of a `FnvHasher` state, then create a new
-map using this state with `HashMap::with_hash_state`. A full example:
+The `FnvHashMap` type alias is the easiest way to use the standard library’s
+`HashMap` with FNV.
 
 ```rust
-use std::collections::HashMap;
-use std::hash::BuildHasherDefault;
-use fnv::FnvHasher;
+use fnv::FnvHashMap;
 
-let fnv = BuildHasherDefault::<FnvHasher>::default();
-let mut map = HashMap::with_hasher(fnv);
+let mut map = FnvHashMap::default();
+map.insert(1, "one");
+map.insert(2, "two");
+
+map = FnvHashMap::with_capacity_and_hasher(10, Default::default());
 map.insert(1, "one");
 map.insert(2, "two");
 ```
 
+Note, the standard library’s `HashMap::new` and `HashMap::with_capacity`
+are only implemented for the `RandomState` hasher, so using `Default` to
+get the hasher is the next best option.
+
 
 ## Using FNV in a HashSet
 
-The standard library’s `HashSet` can be configured to use the FNV hasher
-with the same mechanism.
+Similarly, `FnvHashSet` is a type alias for the standard library’s `HashSet`
+with FNV.
 
 ```rust
-use std::collections::HashSet;
-use std::hash::BuildHasherDefault;
-use fnv::FnvHasher;
+use fnv::FnvHashSet;
 
-let fnv = BuildHasherDefault::<FnvHasher>::default();
-let mut set = HashSet::with_hasher(fnv);
+let mut set = FnvHashSet::default();
+set.insert(1);
+set.insert(2);
+
+set = FnvHashSet::with_capacity_and_hasher(10, Default::default());
 set.insert(1);
 set.insert(2);
 ```

--- a/lib.rs
+++ b/lib.rs
@@ -22,36 +22,40 @@
 //! small—a perfect use case for FNV.
 //!
 //!
-//! ## Using FNV in a HashMap
+//! ## Using FNV in a `HashMap`
 //!
-//! To configure a `HashMap` in the standard library to use the FNV hasher, you
-//! must create a default instance of a `FnvHasher` state, then create a new
-//! map using this state with `HashMap::with_hash_state`. A full example:
+//! The `FnvHashMap` type alias is the easiest way to use the standard library’s
+//! `HashMap` with FNV.
 //!
 //! ```rust
-//! use std::collections::HashMap;
-//! use std::hash::BuildHasherDefault;
-//! use fnv::FnvHasher;
+//! use fnv::FnvHashMap;
 //!
-//! let fnv = BuildHasherDefault::<FnvHasher>::default();
-//! let mut map = HashMap::with_hasher(fnv);
+//! let mut map = FnvHashMap::default();
+//! map.insert(1, "one");
+//! map.insert(2, "two");
+//!
+//! map = FnvHashMap::with_capacity_and_hasher(10, Default::default());
 //! map.insert(1, "one");
 //! map.insert(2, "two");
 //! ```
 //!
+//! Note, the standard library’s `HashMap::new` and `HashMap::with_capacity`
+//! are only implemented for the `RandomState` hasher, so using `Default` to
+//! get the hasher is the next best option.
 //!
-//! ## Using FNV in a HashSet
+//! ## Using FNV in a `HashSet`
 //!
-//! The standard library’s `HashSet` can be configured to use the FNV hasher
-//! with the same mechanism.
+//! Similarly, `FnvHashSet` is a type alias for the standard library’s `HashSet`
+//! with FNV.
 //!
 //! ```rust
-//! use std::collections::HashSet;
-//! use std::hash::BuildHasherDefault;
-//! use fnv::FnvHasher;
+//! use fnv::FnvHashSet;
 //!
-//! let fnv = BuildHasherDefault::<FnvHasher>::default();
-//! let mut set = HashSet::with_hasher(fnv);
+//! let mut set = FnvHashSet::default();
+//! set.insert(1);
+//! set.insert(2);
+//!
+//! set = FnvHashSet::with_capacity_and_hasher(10, Default::default());
 //! set.insert(1);
 //! set.insert(2);
 //! ```
@@ -62,7 +66,8 @@
 
 
 use std::default::Default;
-use std::hash::Hasher;
+use std::hash::{Hasher, BuildHasherDefault};
+use std::collections::{HashMap, HashSet};
 
 /// An implementation of the Fowler–Noll–Vo hash function.
 ///
@@ -105,6 +110,16 @@ impl Hasher for FnvHasher {
         *self = FnvHasher(hash);
     }
 }
+
+/// A builder for default FNV hashers.
+pub type FnvBuildHasher = BuildHasherDefault<FnvHasher>;
+
+/// A `HashMap` using a default FNV hasher.
+pub type FnvHashMap<K, V> = HashMap<K, V, FnvBuildHasher>;
+
+/// A `HashSet` using a default FNV hasher.
+pub type FnvHashSet<T> = HashSet<T, FnvBuildHasher>;
+
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
This is a much easier way to use FNV in the standard collections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-fnv/12)
<!-- Reviewable:end -->
