### PR TITLE
2018 edition, no_std and use hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,11 @@ license = "Apache-2.0 / MIT"
 readme = "README.md"
 repository = "https://github.com/servo/rust-fnv"
 documentation = "https://doc.servo.org/fnv/"
+edition = "2018"
 
 [lib]
 name = "fnv"
 path = "lib.rs"
+
+[dependencies]
+hashbrown = "0.1"

--- a/lib.rs
+++ b/lib.rs
@@ -64,10 +64,11 @@
 //! [faq]: https://www.rust-lang.org/en-US/faq.html#why-are-rusts-hashmaps-slow
 //! [graphs]: https://cglab.ca/~abeinges/blah/hash-rs/
 
+#![no_std]
 
-use std::default::Default;
-use std::hash::{Hasher, BuildHasherDefault};
-use std::collections::{HashMap, HashSet};
+use core::default::Default;
+use core::hash::{Hasher, BuildHasherDefault};
+use hashbrown::{HashMap, HashSet};
 
 /// An implementation of the Fowler–Noll–Vo hash function.
 ///
@@ -123,6 +124,8 @@ pub type FnvHashSet<T> = HashSet<T, FnvBuildHasher>;
 
 #[cfg(test)]
 mod test {
+    extern crate std;
+    use std::prelude::v1::*;
     use super::*;
     use std::hash::Hasher;
 


### PR DESCRIPTION
Changes:

(1) Migrate to the 2018 edition.
(2) Turns this crate into a `no_std` crate. It'll benefit a lot of target platforms without a full functional libstd.
(3) Use hashbrown, a high-performance SwissTable hash map (no_std), to replace the one in libstd.

Signed-off-by: Yu Ding <dingelish@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/rust-fnv/20)
<!-- Reviewable:end -->
