### PR TITLE
Add support for no_std compilation through an "std" feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ rust:
   - nightly
   - beta
   - stable
+script:
+  - cargo test --verbose --all # default features
+  - cargo test --verbose --all --no-default-features # excludes std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,7 @@ documentation = "https://doc.servo.org/fnv/"
 [lib]
 name = "fnv"
 path = "lib.rs"
+
+[features]
+default = ["std"]
+std = []

--- a/lib.rs
+++ b/lib.rs
@@ -21,53 +21,66 @@
 //! denial-of-service attacks, and can assume that its inputs are going to be
 //! small—a perfect use case for FNV.
 //!
-//!
-//! ## Using FNV in a `HashMap`
-//!
-//! The `FnvHashMap` type alias is the easiest way to use the standard library’s
-//! `HashMap` with FNV.
-//!
-//! ```rust
-//! use fnv::FnvHashMap;
-//!
-//! let mut map = FnvHashMap::default();
-//! map.insert(1, "one");
-//! map.insert(2, "two");
-//!
-//! map = FnvHashMap::with_capacity_and_hasher(10, Default::default());
-//! map.insert(1, "one");
-//! map.insert(2, "two");
-//! ```
-//!
-//! Note, the standard library’s `HashMap::new` and `HashMap::with_capacity`
-//! are only implemented for the `RandomState` hasher, so using `Default` to
-//! get the hasher is the next best option.
-//!
-//! ## Using FNV in a `HashSet`
-//!
-//! Similarly, `FnvHashSet` is a type alias for the standard library’s `HashSet`
-//! with FNV.
-//!
-//! ```rust
-//! use fnv::FnvHashSet;
-//!
-//! let mut set = FnvHashSet::default();
-//! set.insert(1);
-//! set.insert(2);
-//!
-//! set = FnvHashSet::with_capacity_and_hasher(10, Default::default());
-//! set.insert(1);
-//! set.insert(2);
-//! ```
+#![cfg_attr(feature = "std", doc = r#"
+
+## Using FNV in a `HashMap`
+
+The `FnvHashMap` type alias is the easiest way to use the standard library’s
+`HashMap` with FNV.
+
+```rust
+use fnv::FnvHashMap;
+
+let mut map = FnvHashMap::default();
+map.insert(1, "one");
+map.insert(2, "two");
+
+map = FnvHashMap::with_capacity_and_hasher(10, Default::default());
+map.insert(1, "one");
+map.insert(2, "two");
+```
+
+Note, the standard library’s `HashMap::new` and `HashMap::with_capacity`
+are only implemented for the `RandomState` hasher, so using `Default` to
+get the hasher is the next best option.
+
+## Using FNV in a `HashSet`
+
+Similarly, `FnvHashSet` is a type alias for the standard library’s `HashSet`
+with FNV.
+
+```rust
+use fnv::FnvHashSet;
+
+let mut set = FnvHashSet::default();
+set.insert(1);
+set.insert(2);
+
+set = FnvHashSet::with_capacity_and_hasher(10, Default::default());
+set.insert(1);
+set.insert(2);
+```
+"#)]
 //!
 //! [chongo]: http://www.isthe.com/chongo/tech/comp/fnv/index.html
 //! [faq]: https://www.rust-lang.org/en-US/faq.html#why-are-rusts-hashmaps-slow
 //! [graphs]: https://cglab.ca/~abeinges/blah/hash-rs/
 
+#![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(all(not(feature = "std"), test))]
+extern crate alloc;
+
+#[cfg(feature = "std")]
 use std::default::Default;
+#[cfg(feature = "std")]
 use std::hash::{Hasher, BuildHasherDefault};
+#[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
+#[cfg(not(feature = "std"))]
+use core::default::Default;
+#[cfg(not(feature = "std"))]
+use core::hash::{Hasher, BuildHasherDefault};
 
 /// An implementation of the Fowler–Noll–Vo hash function.
 ///
@@ -115,16 +128,21 @@ impl Hasher for FnvHasher {
 pub type FnvBuildHasher = BuildHasherDefault<FnvHasher>;
 
 /// A `HashMap` using a default FNV hasher.
+#[cfg(feature = "std")]
 pub type FnvHashMap<K, V> = HashMap<K, V, FnvBuildHasher>;
 
 /// A `HashSet` using a default FNV hasher.
+#[cfg(feature = "std")]
 pub type FnvHashSet<T> = HashSet<T, FnvBuildHasher>;
 
 
 #[cfg(test)]
 mod test {
     use super::*;
+    #[cfg(feature = "std")]
     use std::hash::Hasher;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
 
     fn fnv1a(bytes: &[u8]) -> u64 {
         let mut hasher = FnvHasher::default();


### PR DESCRIPTION
This ended up being quite straightforward.  To make sure that I didn't have to change anything else, `alloc` is enabled for tests, and documentation is conditionally excluded when the "std" feature is disabled.