### PR TITLE
Impl `Clone` for `FnvHasher`

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -89,6 +89,7 @@ const PRIME: u64 = 0x100000001b3;
 ///
 /// See the [crate documentation](index.html) for more details.
 #[allow(missing_copy_implementations)]
+#[derive(Clone)]
 pub struct FnvHasher(u64);
 
 impl Default for FnvHasher {


### PR DESCRIPTION
This implement default `Clone` trait for `FnvHasher`, per https://github.com/servo/rust-fnv/issues/32#issuecomment-1847685571