### PR TITLE
Upgrade edition, set categories, MSRV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,19 +11,23 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
-  fmt:
 
+  msrv:
     runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install MSRV version
+      run: cargo install
 
+  fmt:
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -22,13 +22,19 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Install MSRV version
-      run: cargo install
+    - uses: actions/checkout@v4
+    - name: Read crate metadata
+      id: metadata
+      run: echo "rust-version=$(sed -ne 's/rust-version *= *\"\(.*\)\"/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ steps.metadata.outputs.rust-version }}
+    - run: cargo test --verbose
 
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo fmt --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/servo/rust-fnv"
 documentation = "https://doc.servo.org/fnv/"
 categories = ["algorithms", "data-structures"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "fnv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/servo/rust-fnv"
 documentation = "https://doc.servo.org/fnv/"
 categories = ["algorithms", "data-structures"]
 edition = "2021"
+rust-version = "1.56.1"
 
 [lib]
 name = "fnv"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ license = "Apache-2.0 OR MIT"
 readme = "README.md"
 repository = "https://github.com/servo/rust-fnv"
 documentation = "https://doc.servo.org/fnv/"
+categories = ["algorithms", "data-structures"]
+edition = "2018"
 
 [lib]
 name = "fnv"


### PR DESCRIPTION
Upgrade to edition 2021, set MSRV

I used `cargo msrv -- cargo test` tool to find that 1.56.1 is the oldest satisfied MSRV

This PR includes all commits from #28