### PR TITLE
Allow the user to supply their own initial state and prime

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -169,6 +169,10 @@ pub const unsafe fn fnv_hash_with_state_and_prime(
 ) -> u64 {
     let mut hash = initial_state;
     let mut i = 0;
+    // Small optimization to shoo away the bound check
+    if i >= bytes.len() {
+        unsafe { core::hint::unreachable_unchecked(); }
+    }
     while i < bytes.len() {
         hash ^= bytes[i] as u64;
         hash = hash.wrapping_mul(prime);


### PR DESCRIPTION
This allow to user to done some really cool stuff, such as...shoving a constant time random number and prime number generation into the FNV steps!

```rust
const STATE: HashState = HashState {
    initial_state: const_random!(u64),
    prime: const {
        if let Some(prime) = next_prime(const_random!(u64)) {
            prime
        } else {
            next_prime(const_random!(u32) as u64).unwrap()
        }
    },
};

pub struct HashState {
    pub initial_state: u64,
    pub prime: u64,
}

impl HashState {
    #[inline(always)]
    fn hasher(&self) -> impl Hasher {
        FnvHasher::with_key_prime(self.initial_state, self.prime)
    }

    #[inline(always)]
    fn hash_all_lower_case(&self, bytes: &[u8]) -> u64 {
        let mut hasher = self.hasher();
        for c in bytes {
            hasher.write_u8(c.to_ascii_lowercase());
        }
        hasher.finish()
    }

    #[inline(always)]
    pub const fn hash(&self, bytes: &[u8]) -> u64 {
        unsafe { fnv_hash_with_state_and_prime(bytes, self.initial_state, self.prime) }
    }
}
```
This is required for a small project that needs to hash string in order to prevent antivirus software to obviously detect your malicious activity, by hashing the required library key and function name instead. Here the user needs to prove that the new function `fnv_hash_with_state_and_prime` is supplying a right initial state and a good prime number, and I used a constant time evaluation technique for this.

API changes: Basically none. I just added some const function decorator so that it can be used in a const context, which will otherwise be ran in runtime if you are not under a const context anyway. You can keep using the hasher as is.